### PR TITLE
Enter multiple specific worker skills from the UI

### DIFF
--- a/spec/parsing.spec.js
+++ b/spec/parsing.spec.js
@@ -1,4 +1,4 @@
-const {parseWorkload, parseInput} = require('../src/parsing')
+const {parseWorkload, parseWorkers, parseInput} = require('../src/parsing')
 const {average} = require("../src/generator");
 
 describe('parseWorkload', () => {
@@ -16,6 +16,17 @@ describe('parseWorkload', () => {
   });
 });
 
+describe('parseWorkers', () => {
+  it('parses a single worker', () => {
+    expect(parseWorkers('dev')).toEqual([{skills: ['dev']}]);
+    expect(parseWorkers('qa')).toEqual([{skills: ['qa']}]);
+  });
+
+  it('parses multiple workers', () => {
+    expect(parseWorkers('dev, qa')).toEqual([{skills: ['dev']}, {skills: ['qa']}]);
+  });
+})
+
 describe('parseInput', () => {
   const exampleRawInput = {
     title: 'dev: 3, qa: 1',
@@ -27,7 +38,7 @@ describe('parseInput', () => {
 
   const exampleParsedInput = {
     title: 'dev: 3, qa: 1',
-    workers: ['dev', 'qa', 'qa'],
+    workers: [{skills: ['dev']}, {skills: ['qa']}, {skills: ['qa']}],
     wipLimit: "3",
     distribution: average,
     speed: 20,

--- a/spec/parsing.spec.js
+++ b/spec/parsing.spec.js
@@ -1,0 +1,64 @@
+const {parseWorkload, parseInput} = require('../src/parsing')
+const {average} = require("../src/generator");
+
+describe('parseWorkload', () => {
+  it('parses a single workload', () => {
+     expect(parseWorkload('dev: 1')).toEqual({dev: 1});
+     expect(parseWorkload('qa: 3')).toEqual({qa: 3});
+  });
+
+  it('parses multiple workloads', () => {
+    expect(parseWorkload('dev: 1, qa: 2')).toEqual({dev: 1, qa: 2});
+  });
+
+  it('trims whitespace', () => {
+    expect(parseWorkload('    dev: 1    ,  qa: 2  ')).toEqual({dev: 1, qa: 2});
+  });
+});
+
+describe('parseInput', () => {
+  const exampleRawInput = {
+    title: 'dev: 3, qa: 1',
+    workload: 'dev: 3, qa: 1',
+    workers: 'dev, qa, qa',
+    wipLimit: '3',
+    random: true
+  };
+
+  const exampleParsedInput = {
+    title: 'dev: 3, qa: 1',
+    workers: ['dev', 'qa', 'qa'],
+    wipLimit: "3",
+    distribution: average,
+    speed: 20,
+    stories: {
+      amount: 200,
+      work: { dev: 3, qa: 1},
+    }
+  };
+
+  describe('example input was given', function () {
+    it('parses raw input correctly', () => {
+      expect(parseInput(exampleRawInput)).toEqual(exampleParsedInput);
+    });
+  });
+
+  describe('random was checked off', function() {
+    it('does not generate a distribution', () => {
+      expect(parseInput({...exampleRawInput, random: false}).distribution).toBeFalsy();
+    });
+  });
+
+  describe('only 2 workers provided', function() {
+    let rawInputWith2Workers = {...exampleRawInput, workers: 'dev, qa'};
+
+    it('sets speed to 1', () => {
+      expect(parseInput(rawInputWith2Workers).speed).toEqual(1);
+    });
+
+    it('sets the number of stories to 50', () => {
+      expect(parseInput(rawInputWith2Workers).stories.amount).toEqual(50);
+    });
+  });
+
+});

--- a/spec/parsing.spec.js
+++ b/spec/parsing.spec.js
@@ -17,13 +17,17 @@ describe('parseWorkload', () => {
 });
 
 describe('parseWorkers', () => {
-  it('parses a single worker', () => {
+  it('parses a single worker with a single skill', () => {
     expect(parseWorkers('dev')).toEqual([{skills: ['dev']}]);
     expect(parseWorkers('qa')).toEqual([{skills: ['qa']}]);
   });
 
-  it('parses multiple workers', () => {
+  it('parses multiple workers with single skills', () => {
     expect(parseWorkers('dev, qa')).toEqual([{skills: ['dev']}, {skills: ['qa']}]);
+  });
+
+  it('parses a single worker with multiple skills', () => {
+    expect(parseWorkers('dev+qa')).toEqual([{skills: ['dev', 'qa']}]);
   });
 })
 

--- a/spec/scenario.spec.js
+++ b/spec/scenario.spec.js
@@ -51,7 +51,7 @@ describe('scenario', () => {
     beforeEach(() => {
       run({
         id: 1,
-        workers: ['dev'],
+        workers: [{ skills: ['dev'] }],
         stories: {
           amount: 10,
           work: {'dev': 1}
@@ -72,7 +72,7 @@ describe('scenario', () => {
     beforeEach(() => {
       run({
         id: 1,
-        workers: ['dev', 'qa'],
+        workers: [{ skills: ['dev'] }, { skills: ['qa'] }],
         stories: {
           amount: 10,
           work: {'dev': 1, 'qa': 1}
@@ -93,7 +93,7 @@ describe('scenario', () => {
     beforeEach(() => {
       run({
         id: 1,
-        workers: ['all'],
+        workers: [{ skills: ['all'] }],
         stories: {
           amount: 10,
           work: {'dev': 1, 'qa': 1}

--- a/src/parsing.js
+++ b/src/parsing.js
@@ -24,7 +24,13 @@ function parseInput(rawInput) {
 function parseWorkers(input) {
     return input
         .split(',')
-        .map(skill => ({skills: [skill.trim()]}));
+        .map(skillsInput => ({skills: parseSkills(skillsInput)}));
+}
+
+function parseSkills(input) {
+    return input
+        .split('+')
+        .map(skill => skill.trim());
 }
 
 function parseWorkload(input) {

--- a/src/parsing.js
+++ b/src/parsing.js
@@ -1,0 +1,43 @@
+const {average} = require("./generator");
+
+const split = value => value.trim().split(",").map(item => item.trim());
+
+function parseInput(rawInput) {
+    const title = rawInput.title;
+    const workers = split(rawInput.workers);
+    const work = parseWorkload(rawInput.workload);
+    const wipLimit = rawInput.wipLimit;
+    const speed = (workers.length > 2) ? 20 : 1;
+    const numberOfStories = (workers.length > 2) ? 200 : 50;
+    let input = {
+        title,
+        workers,
+        stories: {
+            amount: numberOfStories,
+            work
+        },
+        wipLimit,
+        speed
+    };
+    if (rawInput.random) input.distribution = average
+    return input;
+}
+
+function parseWorkload(input) {
+    return input
+        .trim()
+        .split(',')
+        .map(pair => pair
+            .trim()
+            .split(":")
+        )
+        .reduce((work, pair) => {
+            work[pair[0].trim()] = parseInt(pair[1].trim());
+            return work;
+        }, {})
+}
+
+module.exports = {
+    parseInput,
+    parseWorkload
+};

--- a/src/parsing.js
+++ b/src/parsing.js
@@ -1,10 +1,8 @@
 const {average} = require("./generator");
 
-const split = value => value.trim().split(",").map(item => item.trim());
-
 function parseInput(rawInput) {
     const title = rawInput.title;
-    const workers = split(rawInput.workers);
+    const workers = parseWorkers(rawInput.workers);
     const work = parseWorkload(rawInput.workload);
     const wipLimit = rawInput.wipLimit;
     const speed = (workers.length > 2) ? 20 : 1;
@@ -23,6 +21,12 @@ function parseInput(rawInput) {
     return input;
 }
 
+function parseWorkers(input) {
+    return input
+        .split(',')
+        .map(skill => ({skills: [skill.trim()]}));
+}
+
 function parseWorkload(input) {
     return input
         .trim()
@@ -39,5 +43,6 @@ function parseWorkload(input) {
 
 module.exports = {
     parseInput,
-    parseWorkload
+    parseWorkload,
+    parseWorkers
 };

--- a/src/scenario.js
+++ b/src/scenario.js
@@ -8,9 +8,9 @@ const Scenario = scenario => {
   const id = counter++;
   const wipLimit = scenario.wipLimit || scenario.stories.amount
 
-  const createWorker = (skillName, speed = 1) => {
+  const createWorker = ({ skills: skillNames }, speed = 1) => {
     let skills = {};
-    skills[skillName] = speed
+    skillNames.forEach(skillName => skills[skillName] = speed);
     return new Worker(skills);
   };
 
@@ -28,7 +28,7 @@ const Scenario = scenario => {
 
   const run = () => {
     const board = new Board(columnNames());
-    board.addWorkers(...(scenario.workers.map(skill => createWorker(skill))));
+    board.addWorkers(...(scenario.workers.map(workerDetails => createWorker(workerDetails))));
     board.addWorkItems(...generateWorkItems(generateStory, scenario.stories.amount));
     return board;
   }

--- a/src/setup.js
+++ b/src/setup.js
@@ -7,6 +7,7 @@ const Stats = require('./stats');
 const WorkerStats = require('./worker-stats');
 const Scenario = require("./scenario");
 const LineChart = require("./charts");
+const {parseInput} = require("./parsing");
 
 function createScenarioContainer(scenario) {
     const template = document.querySelector('#scenario-template');
@@ -16,22 +17,6 @@ function createScenarioContainer(scenario) {
     clone.querySelector('.scenario-title').textContent = scenario.title;
     return clone
 }
-
-function parseWorkload(input) {
-  return input
-    .trim()
-    .split(',')
-    .map(pair => pair
-      .trim()
-      .split(":")
-    )
-    .reduce((work, pair) => {
-      work[pair[0].trim()] = parseInt(pair[1].trim());
-      return work;
-    }, {})
-}
-
-const split = value => value.trim().split(",").map(item => item.trim());
 
 function parse(form) {
   const field = fieldName => form.querySelector(`[name="${fieldName}"]`).value;
@@ -43,27 +28,6 @@ function parse(form) {
       wipLimit: field('wip-limit'),
       random: form.querySelector('[name="random"]').checked
   });
-}
-
-function parseInput(rawInput) {
-    const title = rawInput.title;
-    const workers = split(rawInput.workers);
-    const work = parseWorkload(rawInput.workload);
-    const wipLimit = rawInput.wipLimit;
-    const speed = (workers.length > 2) ? 20 : 1;
-    const numberOfStories = (workers.length > 2) ? 200 : 50;
-    let input = {
-        title,
-        workers,
-        stories: {
-            amount: numberOfStories,
-            work
-        },
-        wipLimit,
-        speed
-    };
-    if (rawInput.random) input.distribution = average
-    return input;
 }
 
 function parseScenario(event) {
@@ -90,7 +54,6 @@ document.addEventListener('DOMContentLoaded', () => {
 const wipLimiter = LimitBoardWip();
 
 
-const {average} = require("./generator");
 let currentChart = undefined;
 
 function run(scenario) {

--- a/src/setup.js
+++ b/src/setup.js
@@ -36,24 +36,34 @@ const split = value => value.trim().split(",").map(item => item.trim());
 function parse(form) {
   const field = fieldName => form.querySelector(`[name="${fieldName}"]`).value;
 
-  const title = field('workload');
-  const workers = split(field('workers'));
-  const work = parseWorkload(field('workload'));
-  const wipLimit = field('wip-limit');
-  const speed = (workers.length > 2) ? 20 : 1;
-  const numberOfStories = (workers.length > 2) ? 200 : 50;
-  let input = {
-    title,
-    workers,
-    stories: {
-      amount: numberOfStories,
-      work
-    },
-    wipLimit,
-    speed
-  };
-  if (form.querySelector('[name="random"]').checked) input.distribution = average
-  return input;
+  return parseInput({
+      title: field('workload'),
+      workers: field('workers'),
+      workload: field('workload'),
+      wipLimit: field('wip-limit'),
+      random: form.querySelector('[name="random"]').checked
+  });
+}
+
+function parseInput(rawInput) {
+    const title = rawInput.title;
+    const workers = split(rawInput.workers);
+    const work = parseWorkload(rawInput.workload);
+    const wipLimit = rawInput.wipLimit;
+    const speed = (workers.length > 2) ? 20 : 1;
+    const numberOfStories = (workers.length > 2) ? 200 : 50;
+    let input = {
+        title,
+        workers,
+        stories: {
+            amount: numberOfStories,
+            work
+        },
+        wipLimit,
+        speed
+    };
+    if (rawInput.random) input.distribution = average
+    return input;
 }
 
 function parseScenario(event) {

--- a/src/setup.js
+++ b/src/setup.js
@@ -53,7 +53,6 @@ function parse(form) {
     speed
   };
   if (form.querySelector('[name="random"]').checked) input.distribution = average
-  input.wipLimit = form.querySelector('[name="wip-limit"]').value
   return input;
 }
 


### PR DESCRIPTION
This adds the ability to assign multiple, specific skills to workers from the UI. Skills are separated by a `+`.

E.g.: `dev, dev+qa` would create two workers:
* worker 1 only has the `dev` skill
* worker 2 has the `dev` and `qa` skills

To achieve this, I extracted a `parsing.js` module from `setup.js` which only contains parsing methods that work on primitives (i.e. no `document.querySelector()` stuff). I also took the liberty to write some tests for those methods (see `parsing.spec.js`).

Lastly, I changed the format of the data passed to a scenario (also see changes in `scenario.spec.js`):
* Before the change workers were specified as `scenario = {..., workers: ['dev', 'qa'] }`. 
* After my changes, the workers now look like this: `scenario = {..., workers: [ { skills: ['dev'] }, { skills: ['qa'] } ] }`.

Let me know if this is useful or if you see anything that can be improved :)