### PR TITLE
Added a cycletime histogram

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,9 @@
         <div class="chart col col-4">
             <canvas id="cfd" class="cfd"></canvas>
         </div>
+        <div class="chart col col-4">
+            <canvas id="histogram" class="histogram"></canvas>
+        </div>
     </div>
 
     <div class="row">

--- a/src/histogram.js
+++ b/src/histogram.js
@@ -1,0 +1,87 @@
+const TimeAdjustments = require('./timeAdjustments');
+const Chart = require('chart.js');
+const PubSub = require("pubsub-js");
+
+function createChart(ctx,speed) {
+  const histogram = {}
+  const labels = [];
+  const startTime = new Date();
+
+  const data = {
+    datasets: [
+      {
+        label: 'Cycle time frequency',
+        data: histogram,
+        backgroundColor: 'rgba(54, 162, 235, 0.1)',
+        borderColor: 'rgba(54, 162, 235, 1)',
+        borderWidth: 1,
+        borderRadius: 5,
+        minBarThickness: 3,
+      },
+    ]
+  };
+
+  const config = {
+    type: 'bar',
+    data: data,
+    options: {
+      animation: false,
+      scales: {
+        x: {
+          type: 'linear',
+          title: {
+            display: true,
+            text: 'Cycle time (days)'
+          }
+        },
+        y: {
+          type: 'linear',
+          position: 'left',
+          ticks: {
+            stepSize: 1
+          },
+          title: {
+            display: true,
+            text: 'Frequency (# of work items)'
+          }
+        },
+      },
+      plugins: {
+        legend: {display: true, position: 'bottom', align: 'start'},
+        title: {
+          display: true,
+          text: 'Cycle time histogram'
+        }
+      }
+    }
+  };
+  const chart = new Chart(ctx, config);
+  return {histogram, chart, labels};
+}
+
+function HistogramChart($chart, updateInterval, speed) {
+  const ctx = $chart.getContext('2d');
+
+  let state = createChart(ctx, speed);
+  PubSub.subscribe('board.ready', () => {
+    const timerId = setInterval(() => state.chart.update(), updateInterval);
+    PubSub.subscribe('board.done', () => {
+      clearInterval(timerId);
+      state.chart.update();
+    });
+
+    PubSub.subscribe('workitem.finished', (topic, item) => {
+      duration = item.duration / (TimeAdjustments.multiplicator() * 1000);
+      duration = Math.floor(duration * 10)/10; /* bucket into 10ths of day */
+      if (state.histogram[duration] !== undefined) {
+          state.histogram[duration] = state.histogram[duration] + 1;
+      } else {
+          state.histogram[duration] = 1;
+      }
+    });
+  });
+
+  return state.chart;
+}
+
+module.exports = HistogramChart

--- a/src/setup.js
+++ b/src/setup.js
@@ -7,6 +7,7 @@ const Stats = require('./stats');
 const WorkerStats = require('./worker-stats');
 const Scenario = require("./scenario");
 const LineChart = require("./charts");
+const HistogramChart = require("./histogram");
 const Cfd = require("./CumulativeFlowDiagram");
 const {parseInput} = require("./parsing");
 
@@ -64,6 +65,7 @@ const wipLimiter = LimitBoardWip();
 
 let lineChart = undefined;
 let cfd = undefined;
+let histogram = undefined;
 
 function run(scenario) {
     PubSub.clearAllSubscriptions();
@@ -84,6 +86,9 @@ function run(scenario) {
 
     if(cfd) cfd.destroy()
     cfd = Cfd(document.getElementById('cfd'), 2000, scenario.speed)
+
+    if(histogram) histogram.destroy()
+    histogram = HistogramChart(document.getElementById('histogram'), 1000, scenario.speed)
 
     const board = scenario.run();
 }


### PR DESCRIPTION
This adds a cycle time frequency histogram to the graphs plotted as it was useful to show the distribution of cycletimes when explaining things to teams (especially when starting to talk about SLAs etc, expect another pull request with percentile markers etc)

At the moment it buckets cycletimes into tenths of "days" (bin size) so the histogram is a little more clear. You could do this more intelligently, but this works for now.