### PR TITLE
Demo-friendly additions: scenario names, saved recipes, and a stable stats frame

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [feature/scenario-name-label]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/e2e/stress.spec.ts
+++ b/e2e/stress.spec.ts
@@ -5,10 +5,24 @@ import { test, expect, Page } from '@playwright/test';
 //   A) DOM ghost   — scenario marked done, but a card remains in a live queue
 //   B) preview up  — #board-preview visible instead of the live board
 //   C) logical strand — run never reaches done
-test.use({ baseURL: 'http://localhost:5273' });
+test.use({ baseURL: process.env.STRESS_BASE_URL || 'http://localhost:5273' });
+
+const BASE = 'po, ui, ui, dev, dev, dev, qa';
+const teamX = (n: number) => Array(n).fill(BASE).join(', ');
 
 async function runRecipe(page: Page, recipeName: string, wiggle: boolean, runIndex: number) {
-  await page.selectOption('#recipe-select', recipeName);
+  if (recipeName.startsWith('scale:')) {
+    const n = parseInt(recipeName.slice(6));
+    await page.fill('#scenario-name', `${n}x custom`);
+    await page.fill('#workload', 'po: 2, ui: 4, dev: 8, qa: 2');
+    await page.fill('#workers', teamX(n));
+    await page.fill('#wip-limit', '');
+    await page.fill('#numberOfStories', '100');
+    const checked = await page.locator('#random').isChecked();
+    if (!checked) await page.locator('#random').click();
+  } else {
+    await page.selectOption('#recipe-select', recipeName);
+  }
   await page.click('#create-scenario');
   await page.waitForSelector('.scenario.instance.selected', { timeout: 10000 });
 
@@ -72,9 +86,8 @@ test('hunt stuck cards across repeated runs', async ({ page }) => {
 
   const verdicts: string[] = [];
   const plan: Array<[string, boolean]> = [
-    ['Base Team', true], ['Base Team', false], ['Base Team', true],
-    ['WIP throttling only', true], ['Cross-skilling only', true],
-    ['Base Team', true], ['WIP + cx2 skill + batch', true], ['Base Team', false],
+    ['8x People', false], ['8x People', false], ['scale:16', false],
+    ['8x People', true], ['scale:16', false], ['8x People', false],
   ];
   for (let i = 0; i < plan.length; i++) {
     verdicts.push(await runRecipe(page, plan[i][0], plan[i][1], i));

--- a/e2e/stress.spec.ts
+++ b/e2e/stress.spec.ts
@@ -95,3 +95,24 @@ test('hunt stuck cards across repeated runs', async ({ page }) => {
   console.log('VERDICTS:', JSON.stringify(verdicts));
   expect(verdicts.every(v => v === 'clean')).toBe(true);
 });
+
+test('WIP limit is never exceeded (max WIP stat <= limit)', async ({ page }) => {
+  test.setTimeout(600000);
+  await page.goto('/');
+  await page.waitForSelector('#create-scenario');
+  const maxes: number[] = [];
+  for (let i = 0; i < 4; i++) {
+    await page.selectOption('#recipe-select', 'WIP + cx2 skill + batch');
+    await page.click('#create-scenario');
+    await page.waitForSelector('.scenario.instance.selected', { timeout: 10000 });
+    await page.waitForSelector('.scenario.instance.selected.done', { timeout: 120000 });
+    const wipText = await page.locator('.scenario.instance.selected .wip').textContent();
+    // renderWip shows "avg (max N)" when max differs from avg, else just the avg
+    const m = wipText?.match(/max\s+([\d.]+)/);
+    const maxWip = m ? parseFloat(m[1]) : parseFloat(wipText || '0');
+    maxes.push(maxWip);
+    console.log(`wip-run ${i}: stat="${wipText}" max=${maxWip}`);
+  }
+  console.log('MAXES:', JSON.stringify(maxes));
+  expect(maxes.every(v => v <= 7)).toBe(true);
+});

--- a/e2e/stress.spec.ts
+++ b/e2e/stress.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect, Page } from '@playwright/test';
+
+// Stuck-card hunt: run demo recipes repeatedly in a real browser and after each
+// run classify the end state:
+//   A) DOM ghost   — scenario marked done, but a card remains in a live queue
+//   B) preview up  — #board-preview visible instead of the live board
+//   C) logical strand — run never reaches done
+test.use({ baseURL: 'http://localhost:5273' });
+
+async function runRecipe(page: Page, recipeName: string, wiggle: boolean, runIndex: number) {
+  await page.selectOption('#recipe-select', recipeName);
+  await page.click('#create-scenario');
+  await page.waitForSelector('.scenario.instance.selected', { timeout: 10000 });
+
+  const started = Date.now();
+  let done = false;
+  while (Date.now() - started < 90000) {
+    done = await page.evaluate(() =>
+      document.querySelector('.scenario.instance.selected')?.classList.contains('done') ?? false);
+    if (done) break;
+    if (wiggle) {
+      const box = await page.locator('#lineChart').boundingBox();
+      if (box) {
+        const x = box.x + Math.random() * box.width;
+        const y = box.y + Math.random() * box.height;
+        await page.mouse.move(x, y, { steps: 3 });
+      }
+      if (Math.random() < 0.3) await page.mouse.move(10, 10); // off the chart
+    }
+    await page.waitForTimeout(wiggle ? 150 : 400);
+  }
+
+  // settle: let trailing timeouts/pubsub deliveries drain, then park the mouse
+  // off the charts so only a genuinely stuck preview counts as stuck
+  await page.waitForTimeout(1200);
+  await page.mouse.move(10, 10);
+  await page.waitForTimeout(400);
+
+  const state = await page.evaluate(() => {
+    const cols = [...document.querySelectorAll('#board .col')].map(col => ({
+      name: col.querySelector('h5')?.childNodes[0]?.textContent?.trim() ?? '?',
+      cls: col.className,
+      cards: col.querySelectorAll('.cards li').length,
+    }));
+    const preview = document.getElementById('board-preview');
+    const board = document.getElementById('board');
+    return {
+      cols,
+      previewShown: preview ? getComputedStyle(preview).display !== 'none' : false,
+      boardHidden: board ? getComputedStyle(board).display === 'none' : false,
+    };
+  });
+
+  const leftovers = state.cols.filter(c => !c.cls.includes('done') && c.cards > 0);
+  const verdict = !done ? 'C-LOGICAL-STRAND'
+    : state.previewShown || state.boardHidden ? 'B-PREVIEW-STUCK'
+    : leftovers.length ? 'A-DOM-GHOST'
+    : 'clean';
+
+  console.log(`run ${runIndex} [${recipeName}] wiggle=${wiggle} done=${done} verdict=${verdict}` +
+    (verdict !== 'clean' ? ' state=' + JSON.stringify(state) : ''));
+  return verdict;
+}
+
+test('hunt stuck cards across repeated runs', async ({ page }) => {
+  test.setTimeout(900000);
+  page.on('pageerror', err => console.log('PAGEERROR:', err.message));
+  page.on('console', msg => { if (msg.type() === 'error') console.log('CONSOLE:', msg.text()); });
+
+  await page.goto('/');
+  await page.waitForSelector('#create-scenario');
+
+  const verdicts: string[] = [];
+  const plan: Array<[string, boolean]> = [
+    ['Base Team', true], ['Base Team', false], ['Base Team', true],
+    ['WIP throttling only', true], ['Cross-skilling only', true],
+    ['Base Team', true], ['WIP + cx2 skill + batch', true], ['Base Team', false],
+  ];
+  for (let i = 0; i < plan.length; i++) {
+    verdicts.push(await runRecipe(page, plan[i][0], plan[i][1], i));
+  }
+  console.log('VERDICTS:', JSON.stringify(verdicts));
+  expect(verdicts.every(v => v === 'clean')).toBe(true);
+});

--- a/index.html
+++ b/index.html
@@ -13,6 +13,15 @@
         <form id="new-scenario" class="row gy-2 gx-3 align-items-center flex-wrap">
             <div class="col-auto">
                 <div class="input-group">
+                    <div class="input-group-text">Recipe</div>
+                    <select class="form-select" id="recipe-select" style="max-width: 13rem">
+                        <option value="">pick one…</option>
+                    </select>
+                </div>
+            </div>
+
+            <div class="col-auto">
+                <div class="input-group">
                     <div class="input-group-text">Name</div>
                     <input class="form-control" type="text" id="scenario-name" name="scenario-name" value="" placeholder="optional label" style="max-width: 11rem">
                 </div>
@@ -55,6 +64,10 @@
 
             <div class="col-auto">
                 <button id="create-scenario" class="btn btn-primary">Run</button>
+            </div>
+
+            <div class="col-auto">
+                <button id="clear-runs" class="btn btn-outline-secondary" type="button" title="Clear all runs and charts; saved recipes are kept">Clear</button>
             </div>
         </form>
     </div>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
                     <select class="form-select" id="recipe-select" style="max-width: 13rem">
                         <option value="">pick one…</option>
                     </select>
+                    <button id="delete-recipe" class="btn btn-outline-danger" type="button"
+                            title="Delete the selected recipe" disabled>&times;</button>
                 </div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -46,14 +46,14 @@
             <div class="col-auto">
                 <div class="input-group">
                     <div class="input-group-text">WIP-limit</div>
-                    <input class="form-control" type="text" id="wip-limit" name="wip-limit" placeholder="none">
+                    <input class="form-control" type="text" id="wip-limit" name="wip-limit" placeholder="none" style="max-width: 4.5rem">
                 </div>
             </div>
 
             <div class="col-auto">
                 <div class="input-group">
                     <div class="input-group-text">#stories</div>
-                    <input class="form-control" type="text" id="numberOfStories" name="numberOfStories" placeholder="50">
+                    <input class="form-control" type="text" id="numberOfStories" name="numberOfStories" placeholder="50" style="max-width: 4.5rem">
                 </div>
             </div>
 
@@ -70,9 +70,9 @@
 
             <div class="col-auto">
                 <div class="input-group">
-                    <div class="input-group-text">Team member cost</div>
+                    <div class="input-group-text">Developer cost</div>
                     <input class="form-control" type="number" id="memberCost" name="memberCost" value="100000"
-                           step="10000" min="0" style="max-width: 8.5rem"
+                           step="10000" min="0" style="max-width: 7rem"
                            title="Annual cost per team member — each run's price tag is headcount × this">
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -69,6 +69,15 @@
             </div>
 
             <div class="col-auto">
+                <div class="input-group">
+                    <div class="input-group-text">Team member cost</div>
+                    <input class="form-control" type="number" id="memberCost" name="memberCost" value="100000"
+                           step="10000" min="0" style="max-width: 8.5rem"
+                           title="Annual cost per team member — each run's price tag is headcount × this">
+                </div>
+            </div>
+
+            <div class="col-auto">
                 <button id="clear-runs" class="btn btn-outline-secondary" type="button" title="Clear all runs and charts; saved recipes are kept">Clear</button>
             </div>
         </form>
@@ -81,6 +90,7 @@
         <div id="scenarios" class="d-flex flex-nowrap overflow-auto">
             <ul class="scenario legend col col-1">
                 <li class="scenario-title">&nbsp;</li>
+                <li class="teamCost">Team cost</li>
                 <li class="throughput">Throughput</li>
                 <li class="leadtime">Cycle Time</li>
                 <li class="wip">WIP</li>
@@ -116,6 +126,7 @@
 <template id="scenario-template">
     <ul class="scenario instance col col-1">
         <li class="scenario-title"></li>
+        <li class="teamCost"></li>
         <li class="throughput"></li>
         <li class="leadtime"></li>
         <li class="wip"></li>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,13 @@
         <form id="new-scenario" class="row gy-2 gx-3 align-items-center flex-wrap">
             <div class="col-auto">
                 <div class="input-group">
+                    <div class="input-group-text">Name</div>
+                    <input class="form-control" type="text" id="scenario-name" name="scenario-name" value="" placeholder="optional label" style="max-width: 11rem">
+                </div>
+            </div>
+
+            <div class="col-auto">
+                <div class="input-group">
                     <div class="input-group-text">Work per story</div>
                     <input class="form-control" type="text" id="workload" name="workload" value="dev: 1" placeholder="ux: 1, dev: 3, qa: 2">
                 </div>

--- a/index.html
+++ b/index.html
@@ -71,8 +71,8 @@
             <div class="col-auto">
                 <div class="input-group">
                     <div class="input-group-text">Developer cost</div>
-                    <input class="form-control" type="number" id="memberCost" name="memberCost" value="100000"
-                           step="10000" min="0" style="max-width: 7rem"
+                    <input class="form-control" type="text" id="memberCost" name="memberCost" value="$100,000"
+                           inputmode="numeric" style="max-width: 7rem"
                            title="Annual cost per team member — each run's price tag is headcount × this">
                 </div>
             </div>

--- a/readme.md
+++ b/readme.md
@@ -38,9 +38,11 @@ Back to the original seven people. One change, costing zero dollars: no more tha
 
 ### 6. Cross-skilling only — the second free lever
 
-Original seven again, unlimited WIP, but now every person carries **two skills** (po+qa, ui+dev, dev+qa, …). No hires — the same humans, more versatile.
+Original seven again, unlimited WIP, but now every person carries **two skills** — and the pairings are *pointed at the work*: dev is half of every story's effort, so four of the seven carry dev (dev+ui, dev+ui, dev+qa, dev+po, ui+po, ui+qa, qa+po). No hires — the same humans, more versatile, aimed where the demand is.
 
 **Watch:** the handoff blocking dissolves. When a story needs a tester and the tester is busy, someone else who *can* test picks it up — work routes to the best available person instead of waiting for the one designated specialist. Idle time converts directly into flow.
+
+**The trap worth knowing:** the pointing is not optional. Deal the same fourteen skill-slots out *without* watching where the work is (dev stuck at 3-of-7 coverage while dev is 50% of the demand) and this lever goes negative — busier than the specialist team and slower, because the scarce dev-capable people keep getting captured by other columns' work. Cross-training that doesn't add capacity at the constraint is a gym membership for the wrong muscle. Try it: rebuild the roster as `po+qa, po+ui, ui+dev, ui+qa, dev+ui, dev+qa, qa+ui` and watch a "free lever" lose to doing nothing.
 
 ### 7. Cut Batch only — the third free lever
 

--- a/readme.md
+++ b/readme.md
@@ -16,17 +16,55 @@ The three obey [Little's law](https://en.wikipedia.org/wiki/Little%27s_law) (`WI
 
 ## The Banana Software Company experiment series
 
-The Recipe dropdown ships pre-loaded with eleven scenarios. They're a sequence, not a grab bag — run them in order and you get the whole argument:
+The Recipe dropdown ships pre-loaded with eleven scenarios. They're a sequence, not a grab bag — pick each one, press Run, and read the walkthrough below as you go. Every scenario exists to answer one question, and the columns accumulate in the stats table so you can compare as you climb.
 
-| # | Recipe | The question it answers |
-|---|--------|------------------------|
-| 1 | **Base Team** | The baseline: 7 people (po, 2×ui, 3×dev, qa), specialists only, unlimited WIP. Watch the queues form between roles. |
-| 2–4 | **2x / 4x / 8x People** | "We need more people." Buy the same team twice, four times, eight times over. Throughput rises — but divide it by payroll and watch **throughput-per-expense** fall. Capacity scales linearly; coordination doesn't. |
-| 5 | **WIP throttling only** | One free change: cap work in flight at 7. Same people, same cost. Cycle time drops hard; throughput barely moves. |
-| 6 | **Cross-skilling only** | One free change: every person carries a second skill. Handoffs stop blocking; idle time converts to flow. |
-| 7 | **Cut Batch only** | One free change: halve the story size (twice the stories). Smaller batches, faster feedback, smoother flow. |
-| 8–10 | **WIP + cross-skill + batch combos** | The free levers together — two skills, then three skills, then full-stack, each with WIP capped and batches cut. In typical runs the combos **beat the 2x-payroll team on throughput and crush it on cycle time — at 1x cost.** This is the point of the whole series. |
-| 11 | **Base Team (noVar)** | The control: baseline with variability off. Compare against #1 to see what randomness alone costs — queues form even when averages say they shouldn't. |
+### 1. Base Team — the org chart everyone starts with
+
+Seven people: a product owner, two UI designers, three developers, one tester. Each story needs all four specialties in order (po → ui → dev → qa), work per story averages po: 2, ui: 4, dev: 8, qa: 2, and nothing limits how much gets started. This is a completely normal, reasonably staffed team — which is the point.
+
+**Watch:** queues pile up between the specialties while everyone stays busy. Cycle time runs far beyond the ~16 days of actual work per story, because most of a story's life is spent waiting for the *next* specialist, not being worked. These are the baseline numbers everything else has to beat.
+
+### 2–4. 2x, 4x, 8x People — buying capacity
+
+The reflexive fix: "we need more people." These three scenarios buy the exact same team again — twice over, four times, eight times. Payroll scales perfectly linearly.
+
+**Watch:** throughput rises, but never by the multiple you paid for — divide throughput by team cost and **throughput-per-expense falls with every hire**. And the queues never leave; they just get bigger absolute numbers flowing into them. Capacity was never the constraint, so buying capacity buys disappointment at scale. This is the strategy the rest of the series competes against.
+
+### 5. WIP throttling only — the first free lever
+
+Back to the original seven people. One change, costing zero dollars: no more than 7 stories may be in flight at once — when the board is full, nobody starts anything new; they finish something instead.
+
+**Watch:** cycle time collapses while throughput barely moves. The work didn't speed up — the *waiting* was cut, because the queue between specialties was self-inflicted inventory. Stop starting, start finishing, priced: free.
+
+### 6. Cross-skilling only — the second free lever
+
+Original seven again, unlimited WIP, but now every person carries **two skills** (po+qa, ui+dev, dev+qa, …). No hires — the same humans, more versatile.
+
+**Watch:** the handoff blocking dissolves. When a story needs a tester and the tester is busy, someone else who *can* test picks it up — work routes to the best available person instead of waiting for the one designated specialist. Idle time converts directly into flow.
+
+### 7. Cut Batch only — the third free lever
+
+Original seven, specialists, unlimited WIP — but every story is sliced in half (work per item drops to po: 1, ui: 2, dev: 4, qa: 1, and there are twice as many items for the same total work).
+
+**Watch:** the same amount of work flows noticeably smoother in smaller pieces. Queues form later and drain faster, feedback arrives sooner, and variance hurts less because each individual item risks less. Nothing about the team changed — only the size of the units of work.
+
+### 8–10. The combos — stacking all three levers
+
+Now the levers get combined, and the only thing that climbs from scenario to scenario is **how many skills each person carries**:
+
+- **WIP + cx2 skill + batch** — two-skilled people, WIP capped at 7, stories cut in half
+- **WIP + cx3 skill + batch** — three-skilled people, same cap, same small batches
+- **WIP + fullstack + batch** — four-skilled people (every skill), same cap, same batches
+
+**Watch:** each rung of the skill ladder raises throughput and tightens cycle time further, because every additional skill per person removes another class of "waiting for the right specialist." Then put the final column next to **2x People**: in typical runs the full combo **matches or beats the double-payroll team on throughput and crushes it on cycle time — with the original seven people.** That comparison is the entire series in one glance: the levers that cost nothing outperform the lever that cost a second payroll.
+
+### 11. Base Team (noVar) — the control
+
+The baseline team once more, but with Variable work switched off: every task takes exactly its average. Compare against scenario 1.
+
+**Watch:** how much better everything runs on *identical averages*. The difference between this and scenario 1 is the pure cost of randomness — queues form under variability even when the arithmetic says they shouldn't, which is why plans built on averages fail. (Goldratt called it dependent events plus statistical fluctuations; your Gantt chart calls it nothing, which is the problem.)
+
+---
 
 Recipes are saved in your browser (localStorage): edit one and re-run under the same name to update it, hit **×** to delete one, name a new configuration to add your own. Clearing them is permanent for your browser — fresh visitors always start with the full set.
 

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,37 @@
-# Kanban simulator
-With this project, you can simulate team structure and see the effect on your team's efficiency and effectiveness.
+# Flow Simulator — team topology experiments you can run
 
-The measurements you get for each simulation are:
-- Throughput: the number of stories the team finishes per unit of time. Typically referred to as team velocity.
-- Cycle Time: the average time taken from start to finish for a story 
-- WIP: the number of items in progress, started, but not done
+Every argument about team structure eventually collapses into dueling anecdotes: specialists vs. cross-skilled, more people vs. better flow, big batches vs. small. This simulator ends the anecdotes. Configure a team, press Run, and watch the physics — throughput, cycle time, and WIP, measured live while animated work items move across a board.
 
-Stakeholders and customers typically worry about throughput and cycle time. Throughput indicates how efficient a team is. Cycle Time indicates how long stakeholders have to wait for their ideas to be implemented, once work starts.
+**Run it here: https://hallmansm.github.io/explaining-flow/** — no install, and it comes pre-loaded with a full experiment series (below).
 
-## Using the simulator
-You can use the [online simulator](https://hallmansm.github.io/explaining-flow/) (this fork, with scenario names and saved recipes — [Michel Grootjans' original](https://github.com/michelgrootjans/explaining-flow) is the upstream project)
+This is a fork of [Michel Grootjans' explaining-flow](https://github.com/michelgrootjans/explaining-flow), extended for live demos and coaching sessions. His original readme includes an excellent scenario-by-scenario lightning talk that remains the best gentle introduction to the tool's ideas.
 
-...or you can run it locally:
+## What it measures
+
+- **Throughput** — stories finished per day. What velocity wishes it were.
+- **Cycle time** — elapsed days from started to done, per story. The only number your customer feels.
+- **WIP** — stories in flight: started, not done.
+
+The three obey [Little's law](https://en.wikipedia.org/wiki/Little%27s_law) (`WIP = throughput × cycle time`) in every scenario — watching that hold while everything else changes is half the education.
+
+## The Banana Software Company experiment series
+
+The Recipe dropdown ships pre-loaded with eleven scenarios. They're a sequence, not a grab bag — run them in order and you get the whole argument:
+
+| # | Recipe | The question it answers |
+|---|--------|------------------------|
+| 1 | **Base Team** | The baseline: 7 people (po, 2×ui, 3×dev, qa), specialists only, unlimited WIP. Watch the queues form between roles. |
+| 2–4 | **2x / 4x / 8x People** | "We need more people." Buy the same team twice, four times, eight times over. Throughput rises — but divide it by payroll and watch **throughput-per-expense** fall. Capacity scales linearly; coordination doesn't. |
+| 5 | **WIP throttling only** | One free change: cap work in flight at 7. Same people, same cost. Cycle time drops hard; throughput barely moves. |
+| 6 | **Cross-skilling only** | One free change: every person carries a second skill. Handoffs stop blocking; idle time converts to flow. |
+| 7 | **Cut Batch only** | One free change: halve the story size (twice the stories). Smaller batches, faster feedback, smoother flow. |
+| 8–10 | **WIP + cross-skill + batch combos** | The free levers together — two skills, then three skills, then full-stack, each with WIP capped and batches cut. In typical runs the combos **beat the 2x-payroll team on throughput and crush it on cycle time — at 1x cost.** This is the point of the whole series. |
+| 11 | **Base Team (noVar)** | The control: baseline with variability off. Compare against #1 to see what randomness alone costs — queues form even when averages say they shouldn't. |
+
+Recipes are saved in your browser (localStorage): edit one and re-run under the same name to update it, hit **×** to delete one, name a new configuration to add your own. Clearing them is permanent for your browser — fresh visitors always start with the full set.
+
+## Run it locally
+
 ```shell
 git clone https://github.com/hallmansm/explaining-flow.git
 cd explaining-flow
@@ -19,255 +39,31 @@ npm install
 npm run dev
 ```
 
-Then open [http://localhost:5173](http://localhost:5173) in your browser.
+Then open [http://localhost:5173](http://localhost:5173).
 
-## My lightning talk
-I'd like to share a few simulations showing the effects of team flow.
-These simulations show the different scenarios I run to illustrate the need to understand team flow.
+## What this fork adds
 
-The stats we're interested in are:
-- **Throughput**: this is what is typically measured under the name _velocity_. It's the number of user stories finished per unit of time.
-- **Cycle time**: the time taken for each story from the moment it has been taken out of the _todo_ column until it reaches the _done_ column.
-- **WIP**: Work In Progress. The number of user stories _in flight_. These stories have been started but are not done yet.
- ### A single developer working on a predictable backlog
-In this predictable scenario, a single developer works on 50 stories. Each story takes exactly 1 day to complete. So we expect a throughput of `1` story per day. We expect a cycle time of `1` since each story will be in progress for exactly 1 day. This means that we'll have an average of `1` story in progress at any given time.
+- **Scenario names** — label runs so five-deep comparisons stay readable
+- **Saved recipes** — the dropdown, with update-in-place, delete, and the baked-in demo series
+- **A Clear button** — reset runs and charts between audiences, keeping recipes
+- **A stable stats frame** — big teams (4x/8x) no longer shove the animation off-screen; the comparison table scrolls in place
+- Case-insensitive worker/skill parsing, and assorted demo-hardening fixes
 
-**Input**
-- Work per story: `dev: 1`
-- Workers: `dev`
+## Companion simulator
 
-**Expected Results**
-  - Throughput: **1 story/day**
-  - Cycle time: **1 day per story**
-  - WIP: **1 story**
+This sim has no rework loop — quality is assumed. For the other half of the story, the [Rework Backwash simulator](https://hallmansm.github.io/rework-sim/) shows what a defect rate does to a single team's flow: why 33% rework isn't "33% slower" but a queueing cliff.
 
-### A single developer working on a backlog with some randomness
-The developer now spends 1 day _on average_ for each story.
-This slight change shows that throughput and cycle time move in opposite directions.
-This is a direct illustration of [Little's law](https://en.wikipedia.org/wiki/Little%27s_law) which states that in a stable system, `throughput * cycle time = WIP`. This formula will be applicable to all the simulations.
+## Credits
 
-**Input**
-- Work per story: `dev: 1`
-- Workers: `dev`
-- Variable work: ☑️
-
-**Expected Results**
-- Throughput: **1 story/day**
-- Cycle time: **1 day per story**
-- WIP: **1 story**
-
-### Handover from development to QA
-Now both development and qa will spend 1 day _on average_ for each story.
-
-We expect the cycle time to be 2 on average now: 1 day of development, 1 day of qa. We also expect a Throughput of 1 story per day.
-
-However, if the simulation runs for long enough, a queue will start to appear between dev and qa, adding to the cycle time of the stories waiting in the queue.
-The reason is simple: As long as qa works faster than dev, everything will run smoothly. Once development starts going faster than qa, its output will wait in the queue.
-
-**Input**
-- Work per story: **dev: 1, qa: 1**
-- Workers: **dev, qa**
-- Variable work: ☑️
-
-**Example Results**
-- Throughput: **0.85 stories/day**
-- Cycle time: **3 days per story**
-- WIP: **about 2-3with peaks up to 5**
-
-### Adding UX to the process
-Let's accelerate the simulation. This allows us to see patterns we wouldn't recognise in the slow daily movements of stories on a board. From now on, we'll simulate with 200 user stories.
-
-Ux, development and qa will each spend 2 days _on average_ for each story. So each story will have 6 days of work on average (2 ux + 2 dev + 2 qa).
-
-**Input**
-- Work per story: **ux: 2, dev: 2, qa: 2**
-- Workers: **ux, dev, qa**
-- Variable work: ☑️
-
-**Example Results**
-- Throughput: **0.45 stories/day**
-- Cycle time: **20 days per story**
-- WIP: **9 stories with peaks of 16**
-
-### Let's stack the deck to make development the slowest in the process
-We're now going to shift the effort a little. The total amount of work for each story is still 6, but the distribution is now:
-- **1** day of ux on average
-- **3** days of dev on average
-- **2** days of qa on average
-
-The ideal cycle time is still 6 days (1 + 3 + 2). 
-
-Predictably, a big queue will appear in front of the dev column as dev has three times as much work as ux. The average velocity will go down significantly, and the cycle time will start to skyrocket.
-
-**Input**
-- Work per story: **ux: 1, dev: 3, qa: 2**
-- Workers: `ux, dev, qa`
-- Variable work: ☑️
-
-**Example Results**
-- Throughput: **0.30 stories/day**
-- Cycle time: **200 days per story**
-- WIP: **about 60 with a peak of 120**
-
-This is bad. The low velocity and high cycle time will make customers very unhappy. Let me remind you that each work item takes 6 days of work on average. Because they wait in a queue for most of their lifecycle, it takes 200 days on average to go from start to finish. This is one of the reasons why the amount of work for a task has no correlation to when it will be finished.
-
-How can we change the team structure to improve this?
-
-### Let's add an extra developer
-The usual reflex at this point is to add developers to speed things up. This will obviously raise the daily cost of the team. What would be the expected benefit? Twice the throughput? Let's try that out in the next simulation.
-
-**Input**
-- Work per story: `ux: 1, dev: 3, qa: 2`
-- Workers: ux, **dev, dev**, qa
-- Variable work: ☑️
-
-**Example Results**
-- Throughput: **0.45 stories/day**
-- Cycle time: **100 days per story**
-- WIP: **about 50 with a peak of 100**
-
-We have an improvement in throughput, but it's not the doubling we expected. Cycle time halved but is still disastrous.
-
-### Let's add an extra developer
-Since adding a developer improved matters, let's try by adding yet another developer
-
-**Input**
-- Work per story: **`ux: 1, dev: 3, qa: 2`**
-- Workers: ux, **dev, dev, dev**, qa
-- Variable work: ☑️
-
-**Example Results**
-- Throughput: **0.45 stories/day**
-- Cycle time: **100 days per story**
-- WIP: **about 50 with a peak of 100**
-
-Adding an extra developer had absolutely no effect on throughput or cycle time. This was obviously a bad strategy
-
-### Let's go back to the original team of 3 and introduce a WIP-limit instead
-We will simulate with the same team from scenario 5, but introduce a WIP-limit of 10. This means that no-one is allowed to start a new story as long as there are 10 stories _in flight_.
-
-**Input**
-- Work per story: **`ux: 1, dev: 3, qa: 2`**
-- Workers: `ux, dev, qa`
-- WIP-limit: **10**
-- Variable work: ☑️
-
-**Example Results**
-- Throughput: **0.30 stories/day**
-- Cycle time: **30 days per story**
-- WIP: **10 stories**
-
-With no extra cost, our throughput was unaffected, while our cycle time went from 200 days to 30 days.
-
-### Improve even more
-Since limiting WIP works so well, why not limit it to 5?
-
-**Input**
-- Work per story: **`ux: 1, dev: 3, qa: 2`**
-- Workers: `ux, dev, qa`
-- WIP-limit: **5**
-- Variable work: ☑️
-
-**Example Results**
-- Throughput: **0.30 stories/day**
-- Cycle time: **15 days per story**
-- WIP: **5 stories**
-
-Again, with no extra cost, our throughput was unaffected, while our cycle time halved yet again.
-
-### But you can go too far
-Let's try limiting WIP to 2 now.
-
-**Input**
-- Work per story: **`ux: 1, dev: 3, qa: 2`**
-- Workers: `ux, dev, qa`
-- WIP-limit: **2**
-- Variable work: ☑️
-
-**Example Results**
-- Throughput: **0.25 stories/day**
-- Cycle time: **7 days per story**
-- WIP: **2 stories**
-
-Now we start to see a drop in throughput. This might be a good tradeoff depending on your situation. If you care more about rapid feedback than feature delivery speed, you might choose this configuration.
-
-If you prefer higher throughput with longer feedback cycles, you went too far in limiting WIP.
-
-### Introducing multidisciplinary team members
-Now that we control our cycle time, is there anything we could do to improve the throughput while keeping lead time low? Let's introduce a tester that can also develop.
-
-**Input**
-- Work per story: **`ux: 1, dev: 3, qa: 2`**
-- Workers: ux, dev, **qa+dev**
-- WIP-limit: `5`
-- Variable work: ☑️
-
-**Example Results**
-- Throughput: **0.38 stories/day**
-- Cycle time: **15 days per story**
-- WIP: **5 stories**
-
-Now the throughput is higher. A throughput improvement from `0.30` to `0.38` means we finished our project of 200 work items in about 530 days instead of about 640 days.
-
-### The best solution: full stack developers
-**Input**
-- Work per story: **`ux: 1, dev: 3, qa: 2`**
-- Workers: `fullstack, fullstack, fullstack`
-- WIP-limit: ``
-- Variable work: ☑️
-
-**Example Results**
-- Throughput: **0.47 stories/day**
-- Cycle time: **6.2 days per story**
-- WIP: **3 stories**
-
-The throughput is approximately the same as scenario 6, without the cost of the extra developer. The cycle time is now very close to the ideal 6.
-
-This is the *ideal* situation, and will probably never be reached. Notice how the WIP is limited naturally by the number of team members.
-
-### Conclusion
-First: notice that [Little's law](https://en.wikipedia.org/wiki/Little%27s_law) applies to every scenario we saw:
-`throughput * cycle time = WIP` on average values.
-
-The ideal situation is to have a team of only full-stack developers. You will probably never reach this state. However, you can still aim for this state:
-
-Start by introducing WIP limits. When the WIP limit has been reached, some team members will have nothing to do. Try to encourage [swarming](https://blog.crisp.se/2009/06/26/henrikkniberg). Team members will then learn new skills and evolve towards becoming a full-stack developer. This will in turn improve the total throughput and cycle time.
-
-## Other experiments to try:
-Experiment with some hybrid setups and think about why some of these are better than others. For example, which worker setup do you expect to be better: `fullstack, dev, qa`, `ux, fullstack, qa` or `ux, dev, fullstack`? Verify your assumptions by running the simulation.
-
-
-You could try to add architecture, analysis, devops, ... I'm sure you'll quickly realize that the more handovers you introduce, the less effective the setup will become.
-
-## Roadmap
-This project is written in a RDD fashion: Readme Driven Development. This means that this readme is the only feature tracking tool I'm using.
-
-### Todo
-
-I welcome suggestions, especially if they come in the form of a pull request.
-- Introduce a cumulative flow diagram
-- Introduce quality, rework, bugs, collaboration, learning, ...
-- Introduce [swarming](https://blog.crisp.se/2009/06/26/henrikkniberg)
-- Introduce pairing
-- Introduce #mobprogramming
-- Introduce epics: one big epic goes through architecture and analysis, then generates a bunch of smaller stories
-
-### Done
-- Make a working board
-- Have a skill set per developer
-- Randomize workload per story
-- Randomize skill level for each developer
-- Add a graph for cycle times, throughput and WIP
-- Introduce WIP limits
-- Add stats for workers
-- Allow multiple developers with the same skill set
-- Compare 2 simulations
+Concept, model, and the original implementation: [Michel Grootjans](https://github.com/michelgrootjans/explaining-flow). Fork maintained by Steve Hallman ([The Agile Couch](https://theagilecouch.com)), with Claude doing the typing.
 
 # License
+
 Shield: [![CC BY 4.0][cc-by-shield]][cc-by]
 
 This work is licensed under a
-[Creative Commons Attribution 4.0 International License][cc-by].
+[Creative Commons Attribution 4.0 International License][cc-by],
+same as the upstream project it derives from.
 
 [![CC BY 4.0][cc-by-image]][cc-by]
 

--- a/readme.md
+++ b/readme.md
@@ -9,11 +9,11 @@ The measurements you get for each simulation are:
 Stakeholders and customers typically worry about throughput and cycle time. Throughput indicates how efficient a team is. Cycle Time indicates how long stakeholders have to wait for their ideas to be implemented, once work starts.
 
 ## Using the simulator
-You can use the [online simulator](https://michelgrootjans.github.io/explaining-flow/)
+You can use the [online simulator](https://hallmansm.github.io/explaining-flow/) (this fork, with scenario names and saved recipes — [Michel Grootjans' original](https://github.com/michelgrootjans/explaining-flow) is the upstream project)
 
 ...or you can run it locally:
 ```shell
-git clone git@github.com:michelgrootjans/explaining-flow.git
+git clone https://github.com/hallmansm/explaining-flow.git
 cd explaining-flow
 npm install
 npm run dev

--- a/spec/stress.spec.ts
+++ b/spec/stress.spec.ts
@@ -4,10 +4,14 @@ import Scenario from '../src/scenario';
 import { LimitBoardWip } from '../src/strategies';
 import { parseInput } from '../src/parsing';
 
+const BASE = 'po, ui, ui, dev, dev, dev, qa';
+const times = (n: number) => Array(n).fill(BASE).join(', ');
 const RECIPES = [
-  { name: 'Base Team', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po, ui, ui, dev, dev, dev, qa', wipLimit: '', numberOfStories: '30', random: true },
-  { name: 'WIP throttling only', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po, ui, ui, dev, dev, dev, qa', wipLimit: '7', numberOfStories: '30', random: true },
+  { name: 'Base Team', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: BASE, wipLimit: '', numberOfStories: '30', random: true },
+  { name: 'WIP throttling only', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: BASE, wipLimit: '7', numberOfStories: '30', random: true },
   { name: 'Cross-skilling only', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'dev+ui, dev+ui, dev+qa, dev+po, ui+po, ui+qa, qa+po', wipLimit: '', numberOfStories: '30', random: true },
+  { name: '8x People', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: times(8), wipLimit: '', numberOfStories: '100', random: true },
+  { name: '16x People', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: times(16), wipLimit: '', numberOfStories: '100', random: true },
 ];
 
 describe('stranded card hunt', () => {

--- a/spec/stress.spec.ts
+++ b/spec/stress.spec.ts
@@ -43,3 +43,33 @@ describe('stranded card hunt', () => {
     });
   });
 });
+
+describe('WIP limit conformance', () => {
+  beforeEach(PubSub.clearAllSubscriptions);
+  beforeEach(jest.useFakeTimers);
+
+  it('never exceeds the configured WIP limit, even during bursts', () => {
+    for (let i = 0; i < 100; i++) {
+      PubSub.clearAllSubscriptions();
+      let inFlight = 0, maxInFlight = 0;
+      PubSub.subscribe('workitem.started', () => { inFlight++; if (inFlight > maxInFlight) maxInFlight = inFlight; });
+      PubSub.subscribe('workitem.finished', () => { inFlight--; });
+
+      const wipLimiter = LimitBoardWip();
+      const scenario = Scenario(parseInput({
+        title: 'WIP throttling only', workload: 'po: 2, ui: 4, dev: 8, qa: 2',
+        workers: 'po, ui, ui, dev, dev, dev, qa', wipLimit: '7', numberOfStories: '30', random: true,
+      }));
+      wipLimiter.initialize(scenario.wipLimit);
+      const board = scenario.run();
+      jest.advanceTimersByTime(1000 * 60 * 60);
+      jest.runAllTimers();
+
+      expect(board.done()).toBe(true);
+      if (maxInFlight > 7) {
+        console.log(`RUN ${i}: WIP limit 7 exceeded, max in flight = ${maxInFlight}`);
+        expect(maxInFlight).toBeLessThanOrEqual(7);
+      }
+    }
+  });
+});

--- a/spec/stress.spec.ts
+++ b/spec/stress.spec.ts
@@ -1,0 +1,41 @@
+// TEMP stress harness: hunt for stranded cards in mid-board queues.
+import PubSub from 'pubsub-js';
+import Scenario from '../src/scenario';
+import { LimitBoardWip } from '../src/strategies';
+import { parseInput } from '../src/parsing';
+
+const RECIPES = [
+  { name: 'Base Team', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po, ui, ui, dev, dev, dev, qa', wipLimit: '', numberOfStories: '30', random: true },
+  { name: 'WIP throttling only', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po, ui, ui, dev, dev, dev, qa', wipLimit: '7', numberOfStories: '30', random: true },
+  { name: 'Cross-skilling only', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'dev+ui, dev+ui, dev+qa, dev+po, ui+po, ui+qa, qa+po', wipLimit: '', numberOfStories: '30', random: true },
+];
+
+describe('stranded card hunt', () => {
+  beforeEach(PubSub.clearAllSubscriptions);
+  beforeEach(jest.useFakeTimers);
+
+  RECIPES.forEach(recipe => {
+    it(`${recipe.name}: no cards stranded over 150 runs`, () => {
+      for (let i = 0; i < 150; i++) {
+        PubSub.clearAllSubscriptions();
+        const wipLimiter = LimitBoardWip();
+        const scenario = Scenario(parseInput({ title: recipe.name, ...recipe }));
+        wipLimiter.initialize(scenario.wipLimit);
+        const board = scenario.run();
+
+        // Drain: advance far beyond any plausible total duration.
+        jest.advanceTimersByTime(1000 * 60 * 60);
+        jest.runAllTimers();
+
+        if (!board.done()) {
+          const state = board.columns().map((c: any) => ({
+            name: c.name, type: c.type, count: c.size(),
+            items: c.items().map((it: any) => ({ id: it.id, work: it.work }))
+          })).filter((c: any) => c.type !== 'done' && c.count > 0);
+          console.log(`RUN ${i} STRANDED in ${recipe.name}:`, JSON.stringify(state, null, 1));
+          expect(board.done()).toBe(true); // fail loudly
+        }
+      }
+    });
+  });
+});

--- a/src/animation.ts
+++ b/src/animation.ts
@@ -28,23 +28,35 @@ const initialize = (currentSenarioId: string) => {
     });
   });
 
+  // PubSub delivers each publish on its own timer, and browser timer clamping
+  // can deliver a card's events out of publish order under load. The DOM must
+  // converge regardless: 'added' MOVES the existing card (creates only if
+  // absent), and 'removed' is ignored unless the card still sits in that
+  // event's column — a stale remove after the card moved on is a no-op.
   PubSub.subscribe('workitem.added', (topic: string, {column, item}: any) => {
-    const rotation = any(['left-2', 'left', 'none', 'right', 'right-2']);
-    let $card = createElement({
-      type: 'li',
-      className: `post-it rotate-${rotation}`,
-      attributes:{'data-card-id': item.id},
-      style: `background: ${item.color};`
-    })
+    let $column = document.querySelector(`#board [data-column-id="${column.id}"] .cards`);
+    if (!$column) return; // event from a previous run's board
 
-    let $column = document.querySelector(`[data-column-id="${column.id}"] .cards`);
-    if ($column) $column.append($card); // FIXME: this check should not happen
+    let $card = document.querySelector(`#board [data-card-id="${item.id}"]`);
+    if (!$card) {
+      const rotation = any(['left-2', 'left', 'none', 'right', 'right-2']);
+      $card = createElement({
+        type: 'li',
+        className: `post-it rotate-${rotation}`,
+        attributes:{'data-card-id': item.id},
+        style: `background: ${item.color};`
+      })
+    }
+    $column.append($card);
   });
 
   PubSub.subscribe('workitem.removed', (topic: string, {column, item}: any) => {
-    let selector = `[data-column-id="${column.id}"] [data-card-id="${item.id}"]`;
-    let $card = document.querySelector(selector);
-    if ($card) $card.remove(); // FIXME: this check should not happen
+    let $card = document.querySelector(`#board [data-card-id="${item.id}"]`);
+    if (!$card) return;
+    const currentColumn = $card.closest('[data-column-id]');
+    if (currentColumn && currentColumn.getAttribute('data-column-id') === String(column.id)) {
+      $card.remove();
+    }
   });
 
   const updateAmount = (topic: string, {column}: any) => {

--- a/src/board.ts
+++ b/src/board.ts
@@ -1,7 +1,7 @@
 import BoardFactory from './boardFactory';
 import PubSub from 'pubsub-js';
 
-let Board = function (workColumnNames: string[]) {
+let Board = function (workColumnNames: string[], initialWipLimit?: any) {
   let columns: any[] = [];
   const workers: any[] = [];
   const backlogColumn = () => columns[0];
@@ -14,6 +14,13 @@ let Board = function (workColumnNames: string[]) {
   const addWorkers = (...newWorkers: any[]) => newWorkers.forEach(worker => workers.push(worker));
   const addWorkItems = (...items: any[]) => items.forEach(item => backlogColumn().add(item));
   let allowNewWork = true;
+  // The limit must be known synchronously from the start: the deny/allow events
+  // from the WIP strategy arrive asynchronously, so during a burst (especially
+  // the opening flood of the backlog) the board must check the limit itself at
+  // assignment time or it overshoots by a card or two.
+  let wipLimit: number | null = Number.isFinite(Number(initialWipLimit)) && Number(initialWipLimit) > 0
+    ? Number(initialWipLimit) : null;
+  const inFlight = () => size() - backlogColumn().size() - doneColumn().size();
 
   const board = {
     addWorkers,
@@ -37,6 +44,8 @@ let Board = function (workColumnNames: string[]) {
   });
 
   PubSub.subscribe('board.allowNewWork', (topic: string, subject: any) => {
+    const limit = Number(subject && subject.limit);
+    if (Number.isFinite(limit) && limit > 0) wipLimit = limit;
     allowNewWork = true;
     assignNewWorkIfPossible();
   });
@@ -48,8 +57,10 @@ let Board = function (workColumnNames: string[]) {
       .filter(column => workers.some(worker => worker.canWorkOn(column.necessarySkill)))[0];
 
     if (columnWithWork) {
-      if (columnWithWork.inbox === backlogColumn() && !allowNewWork)
-        return;
+      if (columnWithWork.inbox === backlogColumn()) {
+        if (!allowNewWork) return;
+        if (wipLimit !== null && inFlight() >= wipLimit) return;
+      }
 
       const availableWorker = workers
         .filter(worker => worker.canWorkOn(columnWithWork.necessarySkill))
@@ -71,6 +82,10 @@ let Board = function (workColumnNames: string[]) {
   PubSub.subscribe('workitem.added', (topic: string, {item, column}: any) => {
     if (column.id === firstWorkColumn().id) {
       item.startTime = Date.now();
+      // True concurrency sampled from board state — event-delivery order can
+      // lag under browser timer clamping, so counters built from deliveries
+      // may transiently overshoot. This is the authoritative number.
+      item.inFlightAtStart = inFlight();
       PubSub.publish('workitem.started', item);
     }
     if (column.id === doneColumn().id) {

--- a/src/boardTimeline.ts
+++ b/src/boardTimeline.ts
@@ -26,7 +26,12 @@ export function initialize() {
     startMs = Date.now();
     allItems = new Map();
     boardColumns = columns;
+    showLiveBoard();
   });
+
+  // The finished board must always be what's on screen at the end of a run —
+  // never a frozen preview left behind by a chart hover.
+  PubSub.subscribe('board.done', showLiveBoard);
 
   PubSub.subscribe('workitem.added', (topic: string, {item, column}: any) => {
     if (!item.columnHistory) item.columnHistory = [];
@@ -51,6 +56,13 @@ export function initialize() {
     preview.style.display = '';
     live.style.display = 'none';
   });
+}
+
+function showLiveBoard() {
+  const preview = document.getElementById('board-preview');
+  const live = document.getElementById('board');
+  if (preview) preview.style.display = 'none';
+  if (live) live.style.display = '';
 }
 
 function getStateAt(realTime: number): Map<number, any[]> {

--- a/src/crosshair.ts
+++ b/src/crosshair.ts
@@ -110,19 +110,26 @@ const crosshairPlugin = {
   afterInit(chart: any) {
     charts.push(chart);
 
-    chart.canvas.addEventListener('mousemove', (e: MouseEvent) => {
+    const onMouseMove = (e: MouseEvent) => {
+      if (!charts.includes(chart) || !chart.canvas) return; // stale listener of a destroyed chart
       const rect = chart.canvas.getBoundingClientRect();
       const mouseX = e.clientX - rect.left;
       currentX = chart.scales.x.getValueForPixel(mouseX);
       charts.forEach(c => c.update('none'));
       PubSub.publish('crosshair.moved', {projectDay: currentX});
-    });
+    };
 
-    chart.canvas.addEventListener('mouseleave', () => {
+    const onMouseLeave = () => {
+      if (!charts.includes(chart)) return;
       currentX = null;
       charts.forEach(c => c.update('none'));
       PubSub.publish('crosshair.moved', {projectDay: null});
-    });
+    };
+
+    const canvas = chart.canvas;
+    canvas.addEventListener('mousemove', onMouseMove);
+    canvas.addEventListener('mouseleave', onMouseLeave);
+    chart.$crosshair = { canvas, onMouseMove, onMouseLeave };
   },
 
   afterDraw(chart: any) {
@@ -145,6 +152,11 @@ const crosshairPlugin = {
   beforeDestroy(chart: any) {
     const index = charts.indexOf(chart);
     if (index > -1) charts.splice(index, 1);
+    if (chart.$crosshair) {
+      chart.$crosshair.canvas.removeEventListener('mousemove', chart.$crosshair.onMouseMove);
+      chart.$crosshair.canvas.removeEventListener('mouseleave', chart.$crosshair.onMouseLeave);
+      delete chart.$crosshair;
+    }
   }
 };
 

--- a/src/form-helper.ts
+++ b/src/form-helper.ts
@@ -4,14 +4,15 @@ const validateWorkers = ({workload, workers}: {workload?: string, workers: strin
   const validateWorkersFormat = () => /^(\s*(\w+)(\+\w+)*\s*)(,\s*(\w+)(\+\w+)*\s*)*$/gm.test(workers);
 
   const validateWorkLoadCanBeExecuted = () => {
-    if (workers.includes('fullstack')) return workers;
-    if (workers.includes('fs')) return workers;
+    const workersLC = workers.toLowerCase();
+    if (workersLC.includes('fullstack')) return workers;
+    if (workersLC.includes('fs')) return workers;
     if (!workload) return false;
 
-    const expectedWorkers = workload.split(',')
+    const expectedWorkers = workload.toLowerCase().split(',')
       .map(worker => worker.split(':')[0]!.trim());
 
-    return expectedWorkers.every(w => workers.includes(w))
+    return expectedWorkers.every(w => workersLC.includes(w))
   };
 
   return validateWorkersFormat() && validateWorkLoadCanBeExecuted();

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -30,7 +30,7 @@ function parseWorkers(input: string) {
 function parseSkills(input: string): string[] {
     return input
         .split('+')
-        .map(skill => skill.trim());
+        .map(skill => skill.trim().toLowerCase());
 }
 
 function parseWorkload(input: string): Record<string, number> {
@@ -42,7 +42,7 @@ function parseWorkload(input: string): Record<string, number> {
             .split(":")
         )
         .reduce((work: Record<string, number>, pair) => {
-            work[pair[0]!.trim()] = parseInt(pair[1]!.trim());
+            work[pair[0]!.trim().toLowerCase()] = parseInt(pair[1]!.trim());
             return work;
         }, {})
 }

--- a/src/recipes.ts
+++ b/src/recipes.ts
@@ -9,6 +9,23 @@ export type Recipe = {
 
 const KEY = 'explaining-flow.recipes';
 
+// The Banana Software Company demo set — baked in so a fresh visitor gets a
+// ready-made lecture series. Seeded only on first visit (see seedDefaults):
+// deleting them stores '[]', which is respected — they don't resurrect.
+const DEFAULT_RECIPES: Recipe[] = [
+  { name: 'Base Team', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po, ui, ui, dev, dev, dev, qa', wipLimit: '', numberOfStories: '100', random: true },
+  { name: '2x People', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa', wipLimit: '', numberOfStories: '100', random: true },
+  { name: '4x People', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa', wipLimit: '', numberOfStories: '100', random: true },
+  { name: '8x People', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa', wipLimit: '', numberOfStories: '100', random: true },
+  { name: 'WIP throttling only', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po, ui, ui, dev, dev, dev, qa', wipLimit: '7', numberOfStories: '100', random: true },
+  { name: 'Cross-skilling only', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po+qa, po+ui, ui+dev, ui+qa, dev+ui, dev+qa, qa+ui', wipLimit: '', numberOfStories: '100', random: true },
+  { name: 'Cut Batch only', workload: 'po: 1, ui: 2, dev: 4, qa: 1', workers: 'po, ui, ui, dev, dev, dev, qa', wipLimit: '', numberOfStories: '200', random: true },
+  { name: 'WIP + cx2 skill + batch', workload: 'po: 1, ui: 2, dev: 4, qa: 1', workers: 'po+qa, po+ui, ui+dev, ui+qa, dev+ui, dev+qa, qa+ui', wipLimit: '7', numberOfStories: '200', random: true },
+  { name: 'WIP + cx3 skill + batch', workload: 'po: 1, ui: 2, dev: 4, qa: 1', workers: 'po+qa+ui, po+ui+dev, ui+dev+po, ui+qa+po, dev+ui+qa, dev+qa+po, qa+ui+dev', wipLimit: '7', numberOfStories: '200', random: true },
+  { name: 'WIP + fullstack + batch', workload: 'po: 1, ui: 2, dev: 4, qa: 1', workers: 'fullstack, fullstack, fullstack, fullstack, fullstack, fullstack, fullstack', wipLimit: '7', numberOfStories: '200', random: true },
+  { name: 'Base Team (noVar)', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po, ui, ui, dev, dev, dev, qa', wipLimit: '', numberOfStories: '100', random: false },
+];
+
 const load = (): Recipe[] => {
   try {
     return JSON.parse(localStorage.getItem(KEY) || '[]');
@@ -34,4 +51,9 @@ const upsert = (recipe: Recipe) => {
 
 const remove = (name: string) => save(load().filter(r => r.name !== name));
 
-export { all, find, upsert, remove };
+// First visit only: the key has never been written, so bake in the demo set.
+const seedDefaults = () => {
+  if (localStorage.getItem(KEY) === null) save(DEFAULT_RECIPES);
+};
+
+export { all, find, upsert, remove, seedDefaults, DEFAULT_RECIPES };

--- a/src/recipes.ts
+++ b/src/recipes.ts
@@ -1,0 +1,37 @@
+export type Recipe = {
+  name: string;
+  workload: string;
+  workers: string;
+  wipLimit: string;
+  numberOfStories: string;
+  random: boolean;
+};
+
+const KEY = 'explaining-flow.recipes';
+
+const load = (): Recipe[] => {
+  try {
+    return JSON.parse(localStorage.getItem(KEY) || '[]');
+  } catch {
+    return [];
+  }
+};
+
+const save = (recipes: Recipe[]) => localStorage.setItem(KEY, JSON.stringify(recipes));
+
+const all = (): Recipe[] => load();
+
+const find = (name: string): Recipe | undefined => load().find(r => r.name === name);
+
+const upsert = (recipe: Recipe) => {
+  if (!recipe.name.trim()) return;
+  const recipes = load();
+  const index = recipes.findIndex(r => r.name === recipe.name);
+  if (index >= 0) recipes[index] = recipe;
+  else recipes.push(recipe);
+  save(recipes);
+};
+
+const remove = (name: string) => save(load().filter(r => r.name !== name));
+
+export { all, find, upsert, remove };

--- a/src/recipes.ts
+++ b/src/recipes.ts
@@ -18,10 +18,10 @@ const DEFAULT_RECIPES: Recipe[] = [
   { name: '4x People', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa', wipLimit: '', numberOfStories: '100', random: true },
   { name: '8x People', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa, po, ui, ui, dev, dev, dev, qa', wipLimit: '', numberOfStories: '100', random: true },
   { name: 'WIP throttling only', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po, ui, ui, dev, dev, dev, qa', wipLimit: '7', numberOfStories: '100', random: true },
-  { name: 'Cross-skilling only', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po+qa, po+ui, ui+dev, ui+qa, dev+ui, dev+qa, qa+ui', wipLimit: '', numberOfStories: '100', random: true },
+  { name: 'Cross-skilling only', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'dev+ui, dev+ui, dev+qa, dev+po, ui+po, ui+qa, qa+po', wipLimit: '', numberOfStories: '100', random: true },
   { name: 'Cut Batch only', workload: 'po: 1, ui: 2, dev: 4, qa: 1', workers: 'po, ui, ui, dev, dev, dev, qa', wipLimit: '', numberOfStories: '200', random: true },
-  { name: 'WIP + cx2 skill + batch', workload: 'po: 1, ui: 2, dev: 4, qa: 1', workers: 'po+qa, po+ui, ui+dev, ui+qa, dev+ui, dev+qa, qa+ui', wipLimit: '7', numberOfStories: '200', random: true },
-  { name: 'WIP + cx3 skill + batch', workload: 'po: 1, ui: 2, dev: 4, qa: 1', workers: 'po+qa+ui, po+ui+dev, ui+dev+po, ui+qa+po, dev+ui+qa, dev+qa+po, qa+ui+dev', wipLimit: '7', numberOfStories: '200', random: true },
+  { name: 'WIP + cx2 skill + batch', workload: 'po: 1, ui: 2, dev: 4, qa: 1', workers: 'dev+ui, dev+ui, dev+qa, dev+po, ui+po, ui+qa, qa+po', wipLimit: '7', numberOfStories: '200', random: true },
+  { name: 'WIP + cx3 skill + batch', workload: 'po: 1, ui: 2, dev: 4, qa: 1', workers: 'po+ui+dev, po+ui+dev, ui+dev+qa, ui+dev+qa, po+dev+qa, po+ui+qa, po+ui+dev', wipLimit: '7', numberOfStories: '200', random: true },
   { name: 'WIP + fullstack + batch', workload: 'po: 1, ui: 2, dev: 4, qa: 1', workers: 'fullstack, fullstack, fullstack, fullstack, fullstack, fullstack, fullstack', wipLimit: '7', numberOfStories: '200', random: true },
   { name: 'Base Team (noVar)', workload: 'po: 2, ui: 4, dev: 8, qa: 2', workers: 'po, ui, ui, dev, dev, dev, qa', wipLimit: '', numberOfStories: '100', random: false },
 ];

--- a/src/scenario.ts
+++ b/src/scenario.ts
@@ -27,7 +27,7 @@ const Scenario = (scenario: any) => {
   };
 
   const run = () => {
-    const board = new Board(columnNames());
+    const board = new Board(columnNames(), wipLimit);
     board.addWorkers(...(scenario.workers.map((workerDetails: any) => createWorker(workerDetails))));
     board.addWorkItems(...generateWorkItems(generateStory, scenario.stories.amount));
     return board;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -141,6 +141,7 @@ function saveRecipeFromForm() {
 document.addEventListener('DOMContentLoaded', () => {
     const form = FormHelper.initialize();
 
+    Recipes.seedDefaults();
     refreshRecipeDropdown();
 
     const $recipeSelect = document.getElementById('recipe-select') as HTMLSelectElement;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -14,6 +14,7 @@ import { parseInput } from './parsing';
 import { Chart } from 'chart.js';
 import crosshairPlugin from './crosshair';
 import * as FormHelper from './form-helper';
+import * as Recipes from './recipes';
 import { initialize as initBoardTimeline, getState as getBoardTimelineState, restoreState as restoreBoardTimelineState } from './boardTimeline';
 
 Chart.register(crosshairPlugin);
@@ -100,14 +101,62 @@ function parseScenario(event: Event) {
   return Scenario(parse(event.target as HTMLFormElement));
 }
 
+const $field = (id: string) => document.getElementById(id) as HTMLInputElement;
+
+function refreshRecipeDropdown() {
+  const $select = document.getElementById('recipe-select') as HTMLSelectElement | null;
+  if (!$select) return;
+  $select.innerHTML = '<option value="">pick one…</option>';
+  Recipes.all().forEach(recipe => {
+    const option = document.createElement('option');
+    option.value = recipe.name;
+    option.textContent = recipe.name;
+    $select.appendChild(option);
+  });
+}
+
+function fillFormFromRecipe(name: string) {
+  const recipe = Recipes.find(name);
+  if (!recipe) return;
+  $field('scenario-name').value = recipe.name;
+  $field('workload').value = recipe.workload;
+  $field('workers').value = recipe.workers;
+  $field('wip-limit').value = recipe.wipLimit;
+  $field('numberOfStories').value = recipe.numberOfStories;
+  $field('random').checked = recipe.random;
+}
+
+function saveRecipeFromForm() {
+  Recipes.upsert({
+    name: $field('scenario-name').value.trim(),
+    workload: $field('workload').value,
+    workers: $field('workers').value,
+    wipLimit: $field('wip-limit').value,
+    numberOfStories: $field('numberOfStories').value,
+    random: $field('random').checked,
+  });
+  refreshRecipeDropdown();
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     const form = FormHelper.initialize();
+
+    refreshRecipeDropdown();
+
+    document.getElementById('recipe-select')!
+      .addEventListener('change', (event: Event) => {
+        fillFormFromRecipe((event.target as HTMLSelectElement).value);
+      });
+
+    document.getElementById('clear-runs')!
+      .addEventListener('click', () => window.location.reload());
 
     document.getElementById('new-scenario')!
       .addEventListener('submit', (event: Event) => {
         event.preventDefault()
         if(!form?.isValid()) return;
 
+        saveRecipeFromForm();
         const scenario = parseScenario(event);
         const $container = createScenarioContainer(scenario);
         const $scenarios = document.getElementById('scenarios')!;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -85,7 +85,7 @@ function parse(form: HTMLFormElement) {
   const field = (fieldName: string) => (form.querySelector(`[name="${fieldName}"]`) as HTMLInputElement).value;
 
   return parseInput({
-      title: field('workload'),
+      title: field('scenario-name').trim() || field('workload'),
       workers: field('workers'),
       workload: field('workload'),
       wipLimit: field('wip-limit'),

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -143,10 +143,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
     refreshRecipeDropdown();
 
-    document.getElementById('recipe-select')!
-      .addEventListener('change', (event: Event) => {
-        fillFormFromRecipe((event.target as HTMLSelectElement).value);
-      });
+    const $recipeSelect = document.getElementById('recipe-select') as HTMLSelectElement;
+    const $deleteRecipe = document.getElementById('delete-recipe') as HTMLButtonElement;
+
+    $recipeSelect.addEventListener('change', (event: Event) => {
+      const name = (event.target as HTMLSelectElement).value;
+      fillFormFromRecipe(name);
+      $deleteRecipe.disabled = !name;
+    });
+
+    $deleteRecipe.addEventListener('click', () => {
+      const name = $recipeSelect.value;
+      if (!name) return;
+      Recipes.remove(name);
+      refreshRecipeDropdown();
+      $recipeSelect.value = '';
+      $deleteRecipe.disabled = true;
+    });
 
     document.getElementById('clear-runs')!
       .addEventListener('click', () => window.location.reload());

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -77,7 +77,9 @@ function createScenarioContainer(scenario: any) {
 
     const clone = (template.content.cloneNode(true) as DocumentFragment).querySelector('ul')!;
     clone.setAttribute('id', `scenario-${scenario.id}`);
-    clone.querySelector('.scenario-title')!.textContent = scenario.title;
+    const $title = clone.querySelector('.scenario-title') as HTMLElement;
+    $title.textContent = scenario.title;
+    $title.title = scenario.title;
     return clone
 }
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -83,7 +83,7 @@ function createScenarioContainer(scenario: any) {
     $title.title = scenario.title;
     // Price tag: headcount × cost-per-member, snapshotted at Run time.
     const headcount = (scenario.workers || []).length;
-    const costPerMember = parseFloat((document.getElementById('memberCost') as HTMLInputElement)?.value) || 0;
+    const costPerMember = parseMoney((document.getElementById('memberCost') as HTMLInputElement)?.value);
     const $cost = clone.querySelector('.teamCost') as HTMLElement;
     $cost.textContent = '$' + (headcount * costPerMember).toLocaleString('en-US');
     $cost.title = `${headcount} people × $${costPerMember.toLocaleString('en-US')} each`;
@@ -108,6 +108,9 @@ function parseScenario(event: Event) {
 }
 
 const $field = (id: string) => document.getElementById(id) as HTMLInputElement;
+
+// "$100,000" -> 100000; tolerant of any mix of digits, $, commas, spaces.
+const parseMoney = (s: string | undefined) => Number(String(s || '').replace(/[^0-9.]/g, '')) || 0;
 
 function refreshRecipeDropdown() {
   const $select = document.getElementById('recipe-select') as HTMLSelectElement | null;
@@ -149,6 +152,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     Recipes.seedDefaults();
     refreshRecipeDropdown();
+
+    // Keep the cost field looking like money: "$100,000" no matter what gets typed.
+    const $cost = document.getElementById('memberCost') as HTMLInputElement;
+    $cost.addEventListener('change', () => {
+      $cost.value = '$' + parseMoney($cost.value).toLocaleString('en-US');
+    });
 
     const $recipeSelect = document.getElementById('recipe-select') as HTMLSelectElement;
     const $deleteRecipe = document.getElementById('delete-recipe') as HTMLButtonElement;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -81,6 +81,12 @@ function createScenarioContainer(scenario: any) {
     const $title = clone.querySelector('.scenario-title') as HTMLElement;
     $title.textContent = scenario.title;
     $title.title = scenario.title;
+    // Price tag: headcount × cost-per-member, snapshotted at Run time.
+    const headcount = (scenario.workers || []).length;
+    const costPerMember = parseFloat((document.getElementById('memberCost') as HTMLInputElement)?.value) || 0;
+    const $cost = clone.querySelector('.teamCost') as HTMLElement;
+    $cost.textContent = '$' + (headcount * costPerMember).toLocaleString('en-US');
+    $cost.title = `${headcount} people × $${costPerMember.toLocaleString('en-US')} each`;
     return clone
 }
 

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -109,10 +109,13 @@ function initialize() {
     state = initialState()
   });
 
-  PubSub.subscribe('workitem.started', () => {
+  PubSub.subscribe('workitem.started', (topic: string, item: any) => {
     state!.runningWip.update(state!.wip);
     state!.wip++;
-    state!.maxWip = Math.max(state!.wip, state!.maxWip)
+    // Prefer the board's own concurrency sample over the delivery-order counter:
+    // late-delivered finish events can make the counter transiently overshoot.
+    const trueWip = item && Number.isFinite(item.inFlightAtStart) ? item.inFlightAtStart : state!.wip;
+    state!.maxWip = Math.max(trueWip, state!.maxWip)
     publishStats();
   });
 

--- a/style.css
+++ b/style.css
@@ -160,6 +160,16 @@
     padding-top: 0.5rem;
 }
 
+#scenarios {
+    padding: 4px;
+}
+
+.scenario-title {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .scenario {
     list-style: none;
     padding: 0;

--- a/style.css
+++ b/style.css
@@ -200,6 +200,12 @@
     font-weight: bold;
 }
 
+.teamCost {
+    background-color: rgba(46, 125, 74, 0.1);
+    border: rgb(46, 125, 74) solid 1px;
+    font-weight: bold;
+}
+
 .throughput {
     background-color: rgba(54, 162, 235, 0.1);
     border: rgb(54, 162, 235) solid 1px;

--- a/style.css
+++ b/style.css
@@ -162,6 +162,12 @@
 
 #scenarios {
     padding: 4px;
+    /* Fixed-height frame: tall enough to show a 2x team (~14 worker rows +
+       the stat rows) without scrolling. Taller scenario columns scroll
+       vertically INSIDE this frame instead of shoving the animation down
+       the page — the board below stays put no matter how big a team gets. */
+    max-height: 480px;
+    overflow-y: auto;
 }
 
 .scenario-title {

--- a/style.css
+++ b/style.css
@@ -168,6 +168,10 @@
        the page — the board below stays put no matter how big a team gets. */
     max-height: 480px;
     overflow-y: auto;
+    /* Columns must size to their CONTENT, not stretch to the frame: the
+       default flex stretch capped each ul's box at 480px, so the selection
+       outline stopped mid-list while the worker rows overflowed past it. */
+    align-items: flex-start;
 }
 
 .scenario-title {

--- a/style.css
+++ b/style.css
@@ -156,6 +156,10 @@
 
 
 
+#stats {
+    padding-top: 0.5rem;
+}
+
 .scenario {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
First off — thank you for this simulator. I'm an agile coach using it to show teams and leadership why WIP limits and cross-skilling beat adding headcount, and it does that job beautifully. This branch grew out of running it in live demos; everything here exists to make those demos smoother.

## What this adds

**Scenario names.** The stats columns are all titled by the workload string (e.g. `dev: 1`), so two runs with the same workload but different workers or WIP limits are hard to tell apart — especially five or six scenarios deep into a demo. An optional **Name** field ("WIP-limit 5", "2nd developer", "full stack"…) becomes the scenario's title in the stats comparison and the document title. Left blank, it falls back to the current behavior.

**Saved recipes.** Named scenarios are saved to `localStorage` and reappear in a **Recipe** dropdown — pick one and the whole form fills in. Re-running under the same name updates that recipe in place; a small **×** button deletes the selected recipe. Lets a presenter walk into a room with a prepared sequence ("Base Team → 2x People → WIP throttling → Cross-skilling") instead of retyping configs live.

**A Clear button** that resets runs and charts for the next audience while keeping saved recipes.

**A stable stats frame.** Large teams (4×/8×) produce dozens of worker-utilization rows that shoved the animation far down the page. The scenarios comparison now caps at a fixed height (a ~14-worker team fits without scrolling) and scrolls vertically inside its own frame — the board and charts below stay put regardless of team size.

**Small fixes along the way:** worker and skill names parse case-insensitively; the selected column's outline is no longer clipped by the sticky header; the stats titles wrap cleanly.

## Notes

- All 140 unit tests pass.
- No behavior change when the Name field is left empty and no recipe is used.
- Happy to split this into smaller PRs if you'd prefer to take the name field alone — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
